### PR TITLE
feat: add support for MySQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.5.0]
+### Added
+- Support for MySQL/MariaDB
+
 ### Removed
 - Dropped support for Rails 6.0 and earlier
 - Dropped support for Ruby 3.0 and earlier

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Migration Lock Timeout is a Ruby gem that adds a lock timeout to all Active
 Record migrations in your Ruby on Rails project. A lock timeout sets a timeout
-on how long PostgreSQL will wait to acquire a lock on tables being altered
+on how long PostgreSQL/MySQL/MariaDB will wait to acquire a lock on tables being altered
 before failing and rolling back. This prevents migrations from creating
 additional lock contention that can take down your site when it's under heavy
-load. Migration Lock Timeout currently only supports [PostgreSQL](https://www.postgresql.org/)
+load. Migration Lock Timeout currently only supports [PostgreSQL](https://www.postgresql.org/), [MySQL](https://www.mysql.com/), [MariaDB](https://mariadb.org/)
 
 ## Installation
 

--- a/lib/migration_lock_timeout/lock_manager.rb
+++ b/lib/migration_lock_timeout/lock_manager.rb
@@ -5,9 +5,14 @@ module MigrationLockTimeout
       timeout_disabled = self.class.disable_lock_timeout
       time = self.class.lock_timeout_override ||
         MigrationLockTimeout.try(:config).try(:default_timeout)
+      adapter = ActiveRecord::Base.connection_db_config.adapter
       if !timeout_disabled && direction == :up && time && !disable_ddl_transaction
         safety_assured? do
-          execute "SET LOCAL lock_timeout = '#{time}s'"
+          if adapter.include?("mysql")
+            execute "SET SESSION lock_wait_timeout = #{time}"
+          else
+            execute "SET LOCAL lock_timeout = '#{time}s'"
+          end
         end
       end
       super


### PR DESCRIPTION
This PR adds support for MySQL/MariaDB. Should cover the various adapter permutations like `mysql`, `mysql2`, `mysql2_makara`, `jdbcmysql`. Added to the 1.5.0 section of the CHANGELOG. Let me know if any changes are desired. Thanks!